### PR TITLE
Separate <add> XML fragment creation into interface.

### DIFF
--- a/Apache/Solr/Compatibility/AddDocumentXmlCreator.php
+++ b/Apache/Solr/Compatibility/AddDocumentXmlCreator.php
@@ -1,0 +1,24 @@
+<?php
+
+interface Apache_Solr_Compatibility_AddDocumentXmlCreator
+{
+    /**
+     * Creates an add command XML string
+     *
+     * @param string  $rawDocuments String containing XML representation of documents.
+     * @param boolean $allowDups
+     * @param boolean $overwritePending
+     * @param boolean $overwriteCommitted
+     * @param integer $commitWithin The number of milliseconds that a document must be committed within,
+     *          see @{link http://wiki.apache.org/solr/UpdateXmlMessages#The_Update_Schema} for details. If left empty
+     *          this property will not be set in the request.
+     * @return string An XML string
+     */
+    public function createAddDocumentXmlFragment(
+        $rawDocuments,
+        $allowDups = false,
+        $overwritePending = true,
+        $overwriteCommitted = true,
+        $commitWithin = 0
+    );
+} 

--- a/Apache/Solr/Compatibility/Solr4CompatibilityLayer.php
+++ b/Apache/Solr/Compatibility/Solr4CompatibilityLayer.php
@@ -1,6 +1,8 @@
 <?php
 
-class Apache_Solr_Compatibility_Solr4CompatibilityLayer implements Apache_Solr_Compatibility_CompatibilityLayer
+class Apache_Solr_Compatibility_Solr4CompatibilityLayer implements
+	Apache_Solr_Compatibility_CompatibilityLayer,
+	Apache_Solr_Compatibility_AddDocumentXmlCreator
 {
 	/**
 	 * Creates a commit command XML string.
@@ -38,6 +40,37 @@ class Apache_Solr_Compatibility_Solr4CompatibilityLayer implements Apache_Solr_C
 		$rawPost = '<optimize waitSearcher="' . $searcherValue . '" />';
 
 		return $rawPost;
+	}
+
+	/**
+	 * Creates an add command XML string
+	 *
+	 * @param string  $rawDocuments String containing XML representation of documents.
+	 * @param boolean $allowDups
+	 * @param boolean $overwritePending
+	 * @param boolean $overwriteCommitted
+	 * @param integer $commitWithin The number of milliseconds that a document must be committed within,
+	 *        see @{link http://wiki.apache.org/solr/UpdateXmlMessages#The_Update_Schema} for details. If left empty
+	 *        this property will not be set in the request.
+	 * @return string An XML string
+	 */
+	public function createAddDocumentXmlFragment(
+		$rawDocuments,
+		$allowDups = false,
+		$overwritePending = true,
+		$overwriteCommitted = true,
+		$commitWithin = 0
+	) {
+		$dupValue = !$allowDups ? 'true' : 'false';
+
+		$commitWithin = (int) $commitWithin;
+		$commitWithinString = $commitWithin > 0 ? " commitWithin=\"{$commitWithin}\"" : '';
+
+		$addXmlFragment = "<add overwrite=\"{$dupValue}\"{$commitWithinString}>";
+		$addXmlFragment .= $rawDocuments;
+		$addXmlFragment .= '</add>';
+
+		return $addXmlFragment;
 	}
 }
 

--- a/tests/Apache/Solr/ServiceTest.php
+++ b/tests/Apache/Solr/ServiceTest.php
@@ -642,7 +642,43 @@ class Apache_Solr_ServiceTest extends Apache_Solr_ServiceAbstractTest
 		
 		$fixture->addDocument($document);
 	}
-	
+
+	public function testAddDocumentWithSolr4()
+	{
+		// set a mock transport
+		$mockTransport = $this->getMockHttpTransportInterface();
+
+		// setup expected call and response
+		$mockTransport->expects($this->once())
+			->method('performPostRequest')
+			->with(
+			// url
+				$this->equalTo('http://localhost:8180/solr/update?wt=json'),
+
+				// raw post
+				$this->equalTo('<add overwrite="true"><doc><field name="guid">global unique id</field><field name="field">value</field><field name="multivalue">value 1</field><field name="multivalue">value 2</field></doc></add>'),
+
+				// content type
+				$this->equalTo('text/xml; charset=UTF-8'),
+
+				// timeout
+				$this->equalTo(false)
+			)
+			->will($this->returnValue(Apache_Solr_HttpTransport_ResponseTest::get200Response()));
+
+		$fixture = new Apache_Solr_service();
+		$fixture->setHttpTransport($mockTransport);
+		$fixture->setCompatibilityLayer(new Apache_Solr_Compatibility_Solr4CompatibilityLayer());
+
+		$document = new Apache_Solr_Document();
+
+		$document->guid = "global unique id";
+		$document->field = "value";
+		$document->multivalue = array("value 1", "value 2");
+
+		$fixture->addDocument($document);
+	}
+
 	public function testAddDocumentWithFieldBoost()
 	{
 		// set a mock transport

--- a/tests/Apache/Solr/ServiceTest.php
+++ b/tests/Apache/Solr/ServiceTest.php
@@ -679,6 +679,51 @@ class Apache_Solr_ServiceTest extends Apache_Solr_ServiceAbstractTest
 		$fixture->addDocument($document);
 	}
 
+	public function testAddMultipleDocumentsWithSolr4()
+	{
+		// set a mock transport
+		$mockTransport = $this->getMockHttpTransportInterface();
+
+		// setup expected call and response
+		$mockTransport->expects($this->once())
+			->method('performPostRequest')
+			->with(
+			// url
+				$this->equalTo('http://localhost:8180/solr/update?wt=json'),
+
+				// raw post
+				$this->equalTo('<add overwrite="true"><doc><field name="guid">global unique id</field><field name="field">value</field><field name="multivalue">value 1</field><field name="multivalue">value 2</field></doc><doc><field name="guid">global unique id2</field><field name="field">value2</field><field name="multivalue">value 2</field><field name="multivalue">value 3</field></doc></add>'),
+
+				// content type
+				$this->equalTo('text/xml; charset=UTF-8'),
+
+				// timeout
+				$this->equalTo(false)
+			)
+			->will($this->returnValue(Apache_Solr_HttpTransport_ResponseTest::get200Response()));
+
+		$fixture = new Apache_Solr_service();
+		$fixture->setHttpTransport($mockTransport);
+		$fixture->setCompatibilityLayer(new Apache_Solr_Compatibility_Solr4CompatibilityLayer());
+
+		$document0 = new Apache_Solr_Document();
+		$document0->guid = "global unique id";
+		$document0->field = "value";
+		$document0->multivalue = array("value 1", "value 2");
+
+		$document1 = new Apache_Solr_Document();
+		$document1->guid = "global unique id2";
+		$document1->field = "value2";
+		$document1->multivalue = array("value 2", "value 3");
+
+		$fixture->addDocuments(
+			array(
+				$document0,
+				$document1
+			)
+		);
+	}
+
 	public function testAddDocumentWithFieldBoost()
 	{
 		// set a mock transport


### PR DESCRIPTION
Separate `<add>` XML fragment creation into interface, which compatibility layers can implement to indicate they want to generate the `<add>` fragment.

Different solution for #7 as implemented in #8 to maintain backwards compatibility.
